### PR TITLE
Fix health check script

### DIFF
--- a/scripts/check_webapp.sh
+++ b/scripts/check_webapp.sh
@@ -1,2 +1,15 @@
 #!/bin/bash
-curl -I http://localhost:8080/student-webapp
+
+# Exit immediately if any command fails
+set -e
+
+# Query the web application and capture the HTTP status code
+STATUS=$(curl -o /dev/null -s -w "%{http_code}" http://localhost:8080/student-webapp)
+
+# Fail if the application does not return HTTP 200
+if [ "$STATUS" != "200" ]; then
+    echo "Application check failed: expected HTTP 200 but got $STATUS" >&2
+    exit 1
+fi
+
+echo "Application is reachable (HTTP $STATUS)"


### PR DESCRIPTION
## Summary
- exit with an error if the webapp doesn't respond with HTTP 200

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe6b50a6c8331b58e4fc0dfa8fe02